### PR TITLE
Marshaller, unmarshaller, and multicodec reg for different tree types

### DIFF
--- a/commit_tree/marshal.go
+++ b/commit_tree/marshal.go
@@ -1,0 +1,25 @@
+package commit_tree
+
+import (
+	"io"
+
+	"github.com/ipld/go-ipld-prime"
+
+	mt "github.com/vulcanize/go-codec-dagcosmos/merkle_tree"
+)
+
+// Encode provides an IPLD codec encode interface for Tendermint CommitTree IPLDs.
+// This function is registered via the go-ipld-prime link loader for multicodec
+// code XXX when this package is invoked via init.
+// This is a pure wrapping around mt.Encode to expose it from this package
+func Encode(node ipld.Node, w io.Writer) error {
+	return mt.Encode(node, w)
+}
+
+// AppendEncode is like Encode, but it uses a destination buffer directly.
+// This means less copying of bytes, and if the destination has enough capacity,
+// fewer allocations.
+// This is a pure wrapping around mt.AppendEncode to expose it from this package
+func AppendEncode(enc []byte, inNode ipld.Node) ([]byte, error) {
+	return mt.AppendEncode(enc, inNode)
+}

--- a/commit_tree/multicodec.go
+++ b/commit_tree/multicodec.go
@@ -1,0 +1,55 @@
+package commit_tree
+
+import (
+	"io"
+
+	"github.com/ipfs/go-cid"
+	"github.com/ipld/go-ipld-prime"
+	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
+	"github.com/ipld/go-ipld-prime/multicodec"
+	"github.com/ipld/go-ipld-prime/traversal"
+	"github.com/multiformats/go-multihash"
+
+	dagcosmos "github.com/vulcanize/go-codec-dagcosmos"
+)
+
+var (
+	_ ipld.Decoder = Decode
+	_ ipld.Encoder = Encode
+
+	MultiCodecType = uint64(cid.DagCBOR) // TODO: replace this with the chosen codec
+	MultiHashType  = uint64(multihash.SHA2_256)
+)
+
+func init() {
+	multicodec.RegisterDecoder(MultiCodecType, Decode)
+	multicodec.RegisterEncoder(MultiCodecType, Encode)
+}
+
+// AddSupportToChooser takes an existing node prototype chooser and subs in
+// CommitTree for the tendermint commit tree multicodec code.
+func AddSupportToChooser(existing traversal.LinkTargetNodePrototypeChooser) traversal.LinkTargetNodePrototypeChooser {
+	return func(lnk ipld.Link, lnkCtx ipld.LinkContext) (ipld.NodePrototype, error) {
+		if lnk, ok := lnk.(cidlink.Link); ok && lnk.Cid.Prefix().Codec == MultiCodecType {
+			return dagcosmos.Type.MerkleTreeNode, nil
+		}
+		return existing(lnk, lnkCtx)
+	}
+}
+
+// We switched to simpler API names after v1.0.0, so keep the old names around
+// as deprecated forwarding funcs until a future v2+.
+// TODO: consider deprecating Marshal/Unmarshal too, since it's a bit
+// unnecessary to have two supported names for each API.
+
+// Deprecated: use Decode instead.
+func Decoder(na ipld.NodeAssembler, r io.Reader) error { return Decode(na, r) }
+
+// Deprecated: use Decode instead.
+func Unmarshal(na ipld.NodeAssembler, r io.Reader) error { return Decode(na, r) }
+
+// Deprecated: use Encode instead.
+func Encoder(inNode ipld.Node, w io.Writer) error { return Encode(inNode, w) }
+
+// Deprecated: use Encode instead.
+func Marshal(inNode ipld.Node, w io.Writer) error { return Encode(inNode, w) }

--- a/commit_tree/unmarshal.go
+++ b/commit_tree/unmarshal.go
@@ -1,0 +1,25 @@
+package commit_tree
+
+import (
+	"io"
+
+	"github.com/ipld/go-ipld-prime"
+
+	mt "github.com/vulcanize/go-codec-dagcosmos/merkle_tree"
+)
+
+// Decode provides an IPLD codec decode interface for Tendermint CommitTree IPLDs.
+// This function is registered via the go-ipld-prime link loader for multicodec
+// code XXX when this package is invoked via init.
+// This simply wraps mt.DecodeTrieNode with the proper multicodec type
+func Decode(na ipld.NodeAssembler, in io.Reader) error {
+	return mt.DecodeTrieNode(na, in, MultiCodecType)
+}
+
+// DecodeBytes is like Decode, but it uses an input buffer directly.
+// Decode will grab or read all the bytes from an io.Reader anyway, so this can
+// save having to copy the bytes or create a bytes.Buffer.
+// This simply wraps mt.DecodeTrieNodeBytes with the proper multicodec type
+func DecodeBytes(na ipld.NodeAssembler, src []byte) error {
+	return mt.DecodeTrieNodeBytes(na, src, MultiCodecType)
+}

--- a/evidence_tree/marshal.go
+++ b/evidence_tree/marshal.go
@@ -1,0 +1,25 @@
+package evidence_tree
+
+import (
+	"io"
+
+	"github.com/ipld/go-ipld-prime"
+
+	mt "github.com/vulcanize/go-codec-dagcosmos/merkle_tree"
+)
+
+// Encode provides an IPLD codec encode interface for Tendermint EvidenceTree IPLDs.
+// This function is registered via the go-ipld-prime link loader for multicodec
+// code XXX when this package is invoked via init.
+// This is a pure wrapping around mt.Encode to expose it from this package
+func Encode(node ipld.Node, w io.Writer) error {
+	return mt.Encode(node, w)
+}
+
+// AppendEncode is like Encode, but it uses a destination buffer directly.
+// This means less copying of bytes, and if the destination has enough capacity,
+// fewer allocations.
+// This is a pure wrapping around mt.AppendEncode to expose it from this package
+func AppendEncode(enc []byte, inNode ipld.Node) ([]byte, error) {
+	return mt.AppendEncode(enc, inNode)
+}

--- a/evidence_tree/multicodec.go
+++ b/evidence_tree/multicodec.go
@@ -1,0 +1,55 @@
+package evidence_tree
+
+import (
+	"io"
+
+	"github.com/ipfs/go-cid"
+	"github.com/ipld/go-ipld-prime"
+	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
+	"github.com/ipld/go-ipld-prime/multicodec"
+	"github.com/ipld/go-ipld-prime/traversal"
+	"github.com/multiformats/go-multihash"
+
+	dagcosmos "github.com/vulcanize/go-codec-dagcosmos"
+)
+
+var (
+	_ ipld.Decoder = Decode
+	_ ipld.Encoder = Encode
+
+	MultiCodecType = uint64(cid.DagCBOR) // TODO: replace this with the chosen codec
+	MultiHashType  = uint64(multihash.SHA2_256)
+)
+
+func init() {
+	multicodec.RegisterDecoder(MultiCodecType, Decode)
+	multicodec.RegisterEncoder(MultiCodecType, Encode)
+}
+
+// AddSupportToChooser takes an existing node prototype chooser and subs in
+// EvidenceTree for the tendermint evidence tree multicodec code.
+func AddSupportToChooser(existing traversal.LinkTargetNodePrototypeChooser) traversal.LinkTargetNodePrototypeChooser {
+	return func(lnk ipld.Link, lnkCtx ipld.LinkContext) (ipld.NodePrototype, error) {
+		if lnk, ok := lnk.(cidlink.Link); ok && lnk.Cid.Prefix().Codec == MultiCodecType {
+			return dagcosmos.Type.MerkleTreeNode, nil
+		}
+		return existing(lnk, lnkCtx)
+	}
+}
+
+// We switched to simpler API names after v1.0.0, so keep the old names around
+// as deprecated forwarding funcs until a future v2+.
+// TODO: consider deprecating Marshal/Unmarshal too, since it's a bit
+// unnecessary to have two supported names for each API.
+
+// Deprecated: use Decode instead.
+func Decoder(na ipld.NodeAssembler, r io.Reader) error { return Decode(na, r) }
+
+// Deprecated: use Decode instead.
+func Unmarshal(na ipld.NodeAssembler, r io.Reader) error { return Decode(na, r) }
+
+// Deprecated: use Encode instead.
+func Encoder(inNode ipld.Node, w io.Writer) error { return Encode(inNode, w) }
+
+// Deprecated: use Encode instead.
+func Marshal(inNode ipld.Node, w io.Writer) error { return Encode(inNode, w) }

--- a/evidence_tree/unmarshal.go
+++ b/evidence_tree/unmarshal.go
@@ -1,0 +1,25 @@
+package evidence_tree
+
+import (
+	"io"
+
+	"github.com/ipld/go-ipld-prime"
+
+	mt "github.com/vulcanize/go-codec-dagcosmos/merkle_tree"
+)
+
+// Decode provides an IPLD codec decode interface for Tendermint EvidenceTree IPLDs.
+// This function is registered via the go-ipld-prime link loader for multicodec
+// code XXX when this package is invoked via init.
+// This simply wraps mt.DecodeTrieNode with the proper multicodec type
+func Decode(na ipld.NodeAssembler, in io.Reader) error {
+	return mt.DecodeTrieNode(na, in, MultiCodecType)
+}
+
+// DecodeBytes is like Decode, but it uses an input buffer directly.
+// Decode will grab or read all the bytes from an io.Reader anyway, so this can
+// save having to copy the bytes or create a bytes.Buffer.
+// This simply wraps mt.DecodeTrieNodeBytes with the proper multicodec type
+func DecodeBytes(na ipld.NodeAssembler, src []byte) error {
+	return mt.DecodeTrieNodeBytes(na, src, MultiCodecType)
+}

--- a/header/marshal.go
+++ b/header/marshal.go
@@ -8,8 +8,6 @@ import (
 	"github.com/vulcanize/go-codec-dagcosmos/shared"
 
 	"github.com/ipld/go-ipld-prime"
-	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
-	"github.com/multiformats/go-multihash"
 	tmversion "github.com/tendermint/tendermint/proto/tendermint/version"
 	"github.com/tendermint/tendermint/types"
 
@@ -227,20 +225,11 @@ func packLastCommitHash(h *types.Header, node ipld.Node) error {
 	if err != nil {
 		return err
 	}
-	lastCommitLink, err := lastCommitHashNode.AsLink()
-	if err != nil {
-		return err
-	}
-	lastCommitCIDLink, ok := lastCommitLink.(cidlink.Link)
-	if !ok {
-		return fmt.Errorf("header must have a LastCommitHash link")
-	}
-	lcMh := lastCommitCIDLink.Hash()
-	decodedLcMh, err := multihash.Decode(lcMh)
+	lastCommitDigest, err := shared.PackLink(lastCommitHashNode)
 	if err != nil {
 		return fmt.Errorf("unable to decode header LastCommitHash multihash: %v", err)
 	}
-	h.LastCommitHash = decodedLcMh.Digest
+	h.LastCommitHash = lastCommitDigest
 	return nil
 }
 
@@ -249,20 +238,11 @@ func packDataHash(h *types.Header, node ipld.Node) error {
 	if err != nil {
 		return err
 	}
-	dataHashLink, err := dataHashHashNode.AsLink()
-	if err != nil {
-		return err
-	}
-	dataHashCIDLink, ok := dataHashLink.(cidlink.Link)
-	if !ok {
-		return fmt.Errorf("header must have a DataHash link")
-	}
-	dhMh := dataHashCIDLink.Hash()
-	decodedDhMh, err := multihash.Decode(dhMh)
+	dataHashDigest, err := shared.PackLink(dataHashHashNode)
 	if err != nil {
 		return fmt.Errorf("unable to decode header DataHash multihash: %v", err)
 	}
-	h.DataHash = decodedDhMh.Digest
+	h.DataHash = dataHashDigest
 	return nil
 }
 
@@ -271,20 +251,11 @@ func packValidatorsHash(h *types.Header, node ipld.Node) error {
 	if err != nil {
 		return err
 	}
-	validatorHashLink, err := validatorHashHashNode.AsLink()
-	if err != nil {
-		return err
-	}
-	validatorHashCIDLink, ok := validatorHashLink.(cidlink.Link)
-	if !ok {
-		return fmt.Errorf("header must have a ValidatorsHash link")
-	}
-	vhMh := validatorHashCIDLink.Hash()
-	decodedVhMh, err := multihash.Decode(vhMh)
+	valHashDigest, err := shared.PackLink(validatorHashHashNode)
 	if err != nil {
 		return fmt.Errorf("unable to decode header ValidatorsHash multihash: %v", err)
 	}
-	h.ValidatorsHash = decodedVhMh.Digest
+	h.ValidatorsHash = valHashDigest
 	return nil
 }
 
@@ -293,20 +264,11 @@ func packNextValidatorsHash(h *types.Header, node ipld.Node) error {
 	if err != nil {
 		return err
 	}
-	validatorHashLink, err := validatorHashHashNode.AsLink()
-	if err != nil {
-		return err
-	}
-	validatorHashCIDLink, ok := validatorHashLink.(cidlink.Link)
-	if !ok {
-		return fmt.Errorf("header must have a NextValidatorsHash link")
-	}
-	vhMh := validatorHashCIDLink.Hash()
-	decodedVhMh, err := multihash.Decode(vhMh)
+	valHashDigest, err := shared.PackLink(validatorHashHashNode)
 	if err != nil {
 		return fmt.Errorf("unable to decode header NextValidatorsHash multihash: %v", err)
 	}
-	h.NextValidatorsHash = decodedVhMh.Digest
+	h.NextValidatorsHash = valHashDigest
 	return nil
 }
 
@@ -315,20 +277,11 @@ func packConsensusHash(h *types.Header, node ipld.Node) error {
 	if err != nil {
 		return err
 	}
-	consensusHashLink, err := consensusHashHashNode.AsLink()
-	if err != nil {
-		return err
-	}
-	consensusHashCIDLink, ok := consensusHashLink.(cidlink.Link)
-	if !ok {
-		return fmt.Errorf("header must have a ConsensusHash link")
-	}
-	chMh := consensusHashCIDLink.Hash()
-	decodedChMh, err := multihash.Decode(chMh)
+	conHashDigest, err := shared.PackLink(consensusHashHashNode)
 	if err != nil {
 		return fmt.Errorf("unable to decode header ConsensusHash multihash: %v", err)
 	}
-	h.ConsensusHash = decodedChMh.Digest
+	h.ConsensusHash = conHashDigest
 	return nil
 }
 
@@ -337,20 +290,11 @@ func packAppHash(h *types.Header, node ipld.Node) error {
 	if err != nil {
 		return err
 	}
-	appHashLink, err := appHashHashNode.AsLink()
-	if err != nil {
-		return err
-	}
-	appHashCIDLink, ok := appHashLink.(cidlink.Link)
-	if !ok {
-		return fmt.Errorf("header must have a AppHash link")
-	}
-	ahMh := appHashCIDLink.Hash()
-	decodedAhMh, err := multihash.Decode(ahMh)
+	appHashDigest, err := shared.PackLink(appHashHashNode)
 	if err != nil {
 		return fmt.Errorf("unable to decode header AppHash multihash: %v", err)
 	}
-	h.AppHash = decodedAhMh.Digest
+	h.AppHash = appHashDigest
 	return nil
 }
 
@@ -359,20 +303,11 @@ func packLastResultsHash(h *types.Header, node ipld.Node) error {
 	if err != nil {
 		return err
 	}
-	lastResultLink, err := lastResultHashNode.AsLink()
-	if err != nil {
-		return err
-	}
-	lastResultCIDLink, ok := lastResultLink.(cidlink.Link)
-	if !ok {
-		return fmt.Errorf("header must have a LastResultsHash link")
-	}
-	lhMh := lastResultCIDLink.Hash()
-	decodedLhMh, err := multihash.Decode(lhMh)
+	lastResDigest, err := shared.PackLink(lastResultHashNode)
 	if err != nil {
 		return fmt.Errorf("unable to decode header LastResultsHash multihash: %v", err)
 	}
-	h.LastResultsHash = decodedLhMh.Digest
+	h.LastResultsHash = lastResDigest
 	return nil
 }
 
@@ -381,20 +316,11 @@ func packEvidenceHash(h *types.Header, node ipld.Node) error {
 	if err != nil {
 		return err
 	}
-	evidenceLink, err := evidenceHashNode.AsLink()
-	if err != nil {
-		return err
-	}
-	evidenceCIDLink, ok := evidenceLink.(cidlink.Link)
-	if !ok {
-		return fmt.Errorf("header must have a EvidenceHash link")
-	}
-	eMh := evidenceCIDLink.Hash()
-	decodedEMh, err := multihash.Decode(eMh)
+	evidenceHashDigest, err := shared.PackLink(evidenceHashNode)
 	if err != nil {
 		return fmt.Errorf("unable to decode header EvidenceHash multihash: %v", err)
 	}
-	h.EvidenceHash = decodedEMh.Digest
+	h.EvidenceHash = evidenceHashDigest
 	return nil
 }
 

--- a/header_tree/marshal.go
+++ b/header_tree/marshal.go
@@ -1,0 +1,25 @@
+package header_tree
+
+import (
+	"io"
+
+	"github.com/ipld/go-ipld-prime"
+
+	mt "github.com/vulcanize/go-codec-dagcosmos/merkle_tree"
+)
+
+// Encode provides an IPLD codec encode interface for Tendermint HeaderTree IPLDs.
+// This function is registered via the go-ipld-prime link loader for multicodec
+// code XXX when this package is invoked via init.
+// This is a pure wrapping around mt.Encode to expose it from this package
+func Encode(node ipld.Node, w io.Writer) error {
+	return mt.Encode(node, w)
+}
+
+// AppendEncode is like Encode, but it uses a destination buffer directly.
+// This means less copying of bytes, and if the destination has enough capacity,
+// fewer allocations.
+// This is a pure wrapping around mt.AppendEncode to expose it from this package
+func AppendEncode(enc []byte, inNode ipld.Node) ([]byte, error) {
+	return mt.AppendEncode(enc, inNode)
+}

--- a/header_tree/multicodec.go
+++ b/header_tree/multicodec.go
@@ -1,0 +1,55 @@
+package header_tree
+
+import (
+	"io"
+
+	"github.com/ipfs/go-cid"
+	"github.com/ipld/go-ipld-prime"
+	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
+	"github.com/ipld/go-ipld-prime/multicodec"
+	"github.com/ipld/go-ipld-prime/traversal"
+	"github.com/multiformats/go-multihash"
+
+	dagcosmos "github.com/vulcanize/go-codec-dagcosmos"
+)
+
+var (
+	_ ipld.Decoder = Decode
+	_ ipld.Encoder = Encode
+
+	MultiCodecType = uint64(cid.DagCBOR) // TODO: replace this with the chosen codec
+	MultiHashType  = uint64(multihash.SHA2_256)
+)
+
+func init() {
+	multicodec.RegisterDecoder(MultiCodecType, Decode)
+	multicodec.RegisterEncoder(MultiCodecType, Encode)
+}
+
+// AddSupportToChooser takes an existing node prototype chooser and subs in
+// HeaderTree for the tendermint header tree multicodec code.
+func AddSupportToChooser(existing traversal.LinkTargetNodePrototypeChooser) traversal.LinkTargetNodePrototypeChooser {
+	return func(lnk ipld.Link, lnkCtx ipld.LinkContext) (ipld.NodePrototype, error) {
+		if lnk, ok := lnk.(cidlink.Link); ok && lnk.Cid.Prefix().Codec == MultiCodecType {
+			return dagcosmos.Type.MerkleTreeNode, nil
+		}
+		return existing(lnk, lnkCtx)
+	}
+}
+
+// We switched to simpler API names after v1.0.0, so keep the old names around
+// as deprecated forwarding funcs until a future v2+.
+// TODO: consider deprecating Marshal/Unmarshal too, since it's a bit
+// unnecessary to have two supported names for each API.
+
+// Deprecated: use Decode instead.
+func Decoder(na ipld.NodeAssembler, r io.Reader) error { return Decode(na, r) }
+
+// Deprecated: use Decode instead.
+func Unmarshal(na ipld.NodeAssembler, r io.Reader) error { return Decode(na, r) }
+
+// Deprecated: use Encode instead.
+func Encoder(inNode ipld.Node, w io.Writer) error { return Encode(inNode, w) }
+
+// Deprecated: use Encode instead.
+func Marshal(inNode ipld.Node, w io.Writer) error { return Encode(inNode, w) }

--- a/header_tree/unmarshal.go
+++ b/header_tree/unmarshal.go
@@ -1,0 +1,25 @@
+package header_tree
+
+import (
+	"io"
+
+	"github.com/ipld/go-ipld-prime"
+
+	mt "github.com/vulcanize/go-codec-dagcosmos/merkle_tree"
+)
+
+// Decode provides an IPLD codec decode interface for Tendermint HeaderTree IPLDs.
+// This function is registered via the go-ipld-prime link loader for multicodec
+// code XXX when this package is invoked via init.
+// This simply wraps mt.DecodeTrieNode with the proper multicodec type
+func Decode(na ipld.NodeAssembler, in io.Reader) error {
+	return mt.DecodeTrieNode(na, in, MultiCodecType)
+}
+
+// DecodeBytes is like Decode, but it uses an input buffer directly.
+// Decode will grab or read all the bytes from an io.Reader anyway, so this can
+// save having to copy the bytes or create a bytes.Buffer.
+// This simply wraps mt.DecodeTrieNodeBytes with the proper multicodec type
+func DecodeBytes(na ipld.NodeAssembler, src []byte) error {
+	return mt.DecodeTrieNodeBytes(na, src, MultiCodecType)
+}

--- a/ipldsch_satisfaction.go
+++ b/ipldsch_satisfaction.go
@@ -21460,7 +21460,7 @@ func (_MerkleTreeNode__Repr) Kind() ipld.Kind {
 }
 func (n *_MerkleTreeNode__Repr) LookupByString(key string) (ipld.Node, error) {
 	switch key {
-	case "inner":
+	case "root":
 		if n.tag != 1 {
 			return nil, ipld.ErrNotExists{Segment: ipld.PathSegmentOfString(key)}
 		}

--- a/merkle_tree/unmarshal.go
+++ b/merkle_tree/unmarshal.go
@@ -6,6 +6,11 @@ import (
 	"io"
 	"io/ioutil"
 
+	"github.com/vulcanize/go-codec-dagcosmos/commit"
+	"github.com/vulcanize/go-codec-dagcosmos/evidence"
+	"github.com/vulcanize/go-codec-dagcosmos/result"
+	validator "github.com/vulcanize/go-codec-dagcosmos/simple_validator"
+
 	"github.com/ipfs/go-cid"
 	"github.com/ipld/go-ipld-prime"
 	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
@@ -14,7 +19,7 @@ import (
 
 // DecodeTrieNode provides an IPLD codec decode interface for cosmos merkle tree nodes
 // It's not possible to meet the Decode(na ipld.NodeAssembler, in io.Reader) interface
-// for a function that supports all trie types (multicodec types), unlike with encoding.
+// for a function that supports all tree types (multicodec types), unlike with encoding.
 // this is used by Decode functions for each tree type, which are the ones registered to their
 // corresponding multicodec
 func DecodeTrieNode(na ipld.NodeAssembler, in io.Reader, codec uint64) error {
@@ -133,29 +138,29 @@ func unpackValue(ma ipld.MapAssembler, val []byte, codec uint64) error {
 		if err := ma.AssembleKey().AssignString(VALIDATOR_VALUE.String()); err != nil {
 			return err
 		}
-		return dagcosmos_validator.DecodeBytes(ma.AssembleValue(), val)
-	case cid.TendermintPartTree:
-		if err := ma.AssembleKey().AssignString(PART_VALUE.String()); err != nil {
-			return err
-		}
-		return dagcosmos_part.DecodeBytes(ma.AssembleValue(), val)
+		return validator.DecodeBytes(ma.AssembleValue(), val)
 	case cid.TendermintResultTree:
 		if err := ma.AssembleKey().AssignString(RESULT_VALUE.String()); err != nil {
 			return err
 		}
-		return dagcosmos_result.DecodeBytes(ma.AssembleValue(), val)
+		return result.DecodeBytes(ma.AssembleValue(), val)
 	case cid.TendermintEvidenceTree:
 		if err := ma.AssembleKey().AssignString(EVIDENCE_VALUE.String()); err != nil {
 			return err
 		}
-		return dagcosmos_evidence.DecodeBytes(ma.AssembleValue(), val)
+		return evidence.DecodeBytes(ma.AssembleValue(), val)
 	case cid.TendermintCommitTree:
 		if err := ma.AssembleKey().AssignString(COMMIT_VALUE.String()); err != nil {
 			return err
 		}
-		return dagcosmos_commit.DecodeBytes(ma.AssembleValue(), val)
+		return commit.DecodeBytes(ma.AssembleValue(), val)
 	case cid.TendermintHeaderTree:
 		if err := ma.AssembleKey().AssignString(HEADER_VALUE.String()); err != nil {
+			return err
+		}
+		return ma.AssembleValue().AssignBytes(val)
+	case cid.TendermintPartTree:
+		if err := ma.AssembleKey().AssignString(PART_VALUE.String()); err != nil {
 			return err
 		}
 		return ma.AssembleValue().AssignBytes(val)

--- a/part_tree/marshal.go
+++ b/part_tree/marshal.go
@@ -1,0 +1,25 @@
+package header_tree
+
+import (
+	"io"
+
+	"github.com/ipld/go-ipld-prime"
+
+	mt "github.com/vulcanize/go-codec-dagcosmos/merkle_tree"
+)
+
+// Encode provides an IPLD codec encode interface for Tendermint PartTree IPLDs.
+// This function is registered via the go-ipld-prime link loader for multicodec
+// code XXX when this package is invoked via init.
+// This is a pure wrapping around mt.Encode to expose it from this package
+func Encode(node ipld.Node, w io.Writer) error {
+	return mt.Encode(node, w)
+}
+
+// AppendEncode is like Encode, but it uses a destination buffer directly.
+// This means less copying of bytes, and if the destination has enough capacity,
+// fewer allocations.
+// This is a pure wrapping around mt.AppendEncode to expose it from this package
+func AppendEncode(enc []byte, inNode ipld.Node) ([]byte, error) {
+	return mt.AppendEncode(enc, inNode)
+}

--- a/part_tree/multicodec.go
+++ b/part_tree/multicodec.go
@@ -1,0 +1,55 @@
+package header_tree
+
+import (
+	"io"
+
+	"github.com/ipfs/go-cid"
+	"github.com/ipld/go-ipld-prime"
+	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
+	"github.com/ipld/go-ipld-prime/multicodec"
+	"github.com/ipld/go-ipld-prime/traversal"
+	"github.com/multiformats/go-multihash"
+
+	dagcosmos "github.com/vulcanize/go-codec-dagcosmos"
+)
+
+var (
+	_ ipld.Decoder = Decode
+	_ ipld.Encoder = Encode
+
+	MultiCodecType = uint64(cid.DagCBOR) // TODO: replace this with the chosen codec
+	MultiHashType  = uint64(multihash.SHA2_256)
+)
+
+func init() {
+	multicodec.RegisterDecoder(MultiCodecType, Decode)
+	multicodec.RegisterEncoder(MultiCodecType, Encode)
+}
+
+// AddSupportToChooser takes an existing node prototype chooser and subs in
+// PartTree for the tendermint part tree multicodec code.
+func AddSupportToChooser(existing traversal.LinkTargetNodePrototypeChooser) traversal.LinkTargetNodePrototypeChooser {
+	return func(lnk ipld.Link, lnkCtx ipld.LinkContext) (ipld.NodePrototype, error) {
+		if lnk, ok := lnk.(cidlink.Link); ok && lnk.Cid.Prefix().Codec == MultiCodecType {
+			return dagcosmos.Type.MerkleTreeNode, nil
+		}
+		return existing(lnk, lnkCtx)
+	}
+}
+
+// We switched to simpler API names after v1.0.0, so keep the old names around
+// as deprecated forwarding funcs until a future v2+.
+// TODO: consider deprecating Marshal/Unmarshal too, since it's a bit
+// unnecessary to have two supported names for each API.
+
+// Deprecated: use Decode instead.
+func Decoder(na ipld.NodeAssembler, r io.Reader) error { return Decode(na, r) }
+
+// Deprecated: use Decode instead.
+func Unmarshal(na ipld.NodeAssembler, r io.Reader) error { return Decode(na, r) }
+
+// Deprecated: use Encode instead.
+func Encoder(inNode ipld.Node, w io.Writer) error { return Encode(inNode, w) }
+
+// Deprecated: use Encode instead.
+func Marshal(inNode ipld.Node, w io.Writer) error { return Encode(inNode, w) }

--- a/part_tree/unmarshal.go
+++ b/part_tree/unmarshal.go
@@ -1,0 +1,25 @@
+package header_tree
+
+import (
+	"io"
+
+	"github.com/ipld/go-ipld-prime"
+
+	mt "github.com/vulcanize/go-codec-dagcosmos/merkle_tree"
+)
+
+// Decode provides an IPLD codec decode interface for Tendermint PartTree IPLDs.
+// This function is registered via the go-ipld-prime link loader for multicodec
+// code XXX when this package is invoked via init.
+// This simply wraps mt.DecodeTrieNode with the proper multicodec type
+func Decode(na ipld.NodeAssembler, in io.Reader) error {
+	return mt.DecodeTrieNode(na, in, MultiCodecType)
+}
+
+// DecodeBytes is like Decode, but it uses an input buffer directly.
+// Decode will grab or read all the bytes from an io.Reader anyway, so this can
+// save having to copy the bytes or create a bytes.Buffer.
+// This simply wraps mt.DecodeTrieNodeBytes with the proper multicodec type
+func DecodeBytes(na ipld.NodeAssembler, src []byte) error {
+	return mt.DecodeTrieNodeBytes(na, src, MultiCodecType)
+}

--- a/result/marshal.go
+++ b/result/marshal.go
@@ -1,4 +1,4 @@
-package params
+package result
 
 import (
 	"encoding/binary"

--- a/result/multicodec.go
+++ b/result/multicodec.go
@@ -1,4 +1,4 @@
-package params
+package result
 
 import (
 	"io"

--- a/result/unmarshal.go
+++ b/result/unmarshal.go
@@ -1,4 +1,4 @@
-package params
+package result
 
 import (
 	"encoding/binary"

--- a/result_tree/marshal.go
+++ b/result_tree/marshal.go
@@ -1,0 +1,25 @@
+package result_tree
+
+import (
+	"io"
+
+	"github.com/ipld/go-ipld-prime"
+
+	mt "github.com/vulcanize/go-codec-dagcosmos/merkle_tree"
+)
+
+// Encode provides an IPLD codec encode interface for Tendermint ResultTree IPLDs.
+// This function is registered via the go-ipld-prime link loader for multicodec
+// code XXX when this package is invoked via init.
+// This is a pure wrapping around mt.Encode to expose it from this package
+func Encode(node ipld.Node, w io.Writer) error {
+	return mt.Encode(node, w)
+}
+
+// AppendEncode is like Encode, but it uses a destination buffer directly.
+// This means less copying of bytes, and if the destination has enough capacity,
+// fewer allocations.
+// This is a pure wrapping around mt.AppendEncode to expose it from this package
+func AppendEncode(enc []byte, inNode ipld.Node) ([]byte, error) {
+	return mt.AppendEncode(enc, inNode)
+}

--- a/result_tree/multicodec.go
+++ b/result_tree/multicodec.go
@@ -1,0 +1,55 @@
+package result_tree
+
+import (
+	"io"
+
+	"github.com/ipfs/go-cid"
+	"github.com/ipld/go-ipld-prime"
+	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
+	"github.com/ipld/go-ipld-prime/multicodec"
+	"github.com/ipld/go-ipld-prime/traversal"
+	"github.com/multiformats/go-multihash"
+
+	dagcosmos "github.com/vulcanize/go-codec-dagcosmos"
+)
+
+var (
+	_ ipld.Decoder = Decode
+	_ ipld.Encoder = Encode
+
+	MultiCodecType = uint64(cid.DagCBOR) // TODO: replace this with the chosen codec
+	MultiHashType  = uint64(multihash.SHA2_256)
+)
+
+func init() {
+	multicodec.RegisterDecoder(MultiCodecType, Decode)
+	multicodec.RegisterEncoder(MultiCodecType, Encode)
+}
+
+// AddSupportToChooser takes an existing node prototype chooser and subs in
+// ResultTree for the tendermint result tree multicodec code.
+func AddSupportToChooser(existing traversal.LinkTargetNodePrototypeChooser) traversal.LinkTargetNodePrototypeChooser {
+	return func(lnk ipld.Link, lnkCtx ipld.LinkContext) (ipld.NodePrototype, error) {
+		if lnk, ok := lnk.(cidlink.Link); ok && lnk.Cid.Prefix().Codec == MultiCodecType {
+			return dagcosmos.Type.MerkleTreeNode, nil
+		}
+		return existing(lnk, lnkCtx)
+	}
+}
+
+// We switched to simpler API names after v1.0.0, so keep the old names around
+// as deprecated forwarding funcs until a future v2+.
+// TODO: consider deprecating Marshal/Unmarshal too, since it's a bit
+// unnecessary to have two supported names for each API.
+
+// Deprecated: use Decode instead.
+func Decoder(na ipld.NodeAssembler, r io.Reader) error { return Decode(na, r) }
+
+// Deprecated: use Decode instead.
+func Unmarshal(na ipld.NodeAssembler, r io.Reader) error { return Decode(na, r) }
+
+// Deprecated: use Encode instead.
+func Encoder(inNode ipld.Node, w io.Writer) error { return Encode(inNode, w) }
+
+// Deprecated: use Encode instead.
+func Marshal(inNode ipld.Node, w io.Writer) error { return Encode(inNode, w) }

--- a/result_tree/unmarshal.go
+++ b/result_tree/unmarshal.go
@@ -1,0 +1,25 @@
+package result_tree
+
+import (
+	"io"
+
+	"github.com/ipld/go-ipld-prime"
+
+	mt "github.com/vulcanize/go-codec-dagcosmos/merkle_tree"
+)
+
+// Decode provides an IPLD codec decode interface for Tendermint ResultTree IPLDs.
+// This function is registered via the go-ipld-prime link loader for multicodec
+// code XXX when this package is invoked via init.
+// This simply wraps mt.DecodeTrieNode with the proper multicodec type
+func Decode(na ipld.NodeAssembler, in io.Reader) error {
+	return mt.DecodeTrieNode(na, in, MultiCodecType)
+}
+
+// DecodeBytes is like Decode, but it uses an input buffer directly.
+// Decode will grab or read all the bytes from an io.Reader anyway, so this can
+// save having to copy the bytes or create a bytes.Buffer.
+// This simply wraps mt.DecodeTrieNodeBytes with the proper multicodec type
+func DecodeBytes(na ipld.NodeAssembler, src []byte) error {
+	return mt.DecodeTrieNodeBytes(na, src, MultiCodecType)
+}

--- a/simple_validator/marshal.go
+++ b/simple_validator/marshal.go
@@ -1,4 +1,4 @@
-package params
+package validator
 
 import (
 	"io"

--- a/simple_validator/multicodec.go
+++ b/simple_validator/multicodec.go
@@ -1,4 +1,4 @@
-package params
+package validator
 
 import (
 	"io"

--- a/simple_validator/unmarshal.go
+++ b/simple_validator/unmarshal.go
@@ -1,4 +1,4 @@
-package params
+package validator
 
 import (
 	"io"

--- a/tx_tree/marshal.go
+++ b/tx_tree/marshal.go
@@ -1,0 +1,25 @@
+package tx_tree
+
+import (
+	"io"
+
+	"github.com/ipld/go-ipld-prime"
+
+	mt "github.com/vulcanize/go-codec-dagcosmos/merkle_tree"
+)
+
+// Encode provides an IPLD codec encode interface for Tendermint TxTree IPLDs.
+// This function is registered via the go-ipld-prime link loader for multicodec
+// code XXX when this package is invoked via init.
+// This is a pure wrapping around mt.Encode to expose it from this package
+func Encode(node ipld.Node, w io.Writer) error {
+	return mt.Encode(node, w)
+}
+
+// AppendEncode is like Encode, but it uses a destination buffer directly.
+// This means less copying of bytes, and if the destination has enough capacity,
+// fewer allocations.
+// This is a pure wrapping around mt.AppendEncode to expose it from this package
+func AppendEncode(enc []byte, inNode ipld.Node) ([]byte, error) {
+	return mt.AppendEncode(enc, inNode)
+}

--- a/tx_tree/multicodec.go
+++ b/tx_tree/multicodec.go
@@ -1,0 +1,55 @@
+package tx_tree
+
+import (
+	"io"
+
+	"github.com/ipfs/go-cid"
+	"github.com/ipld/go-ipld-prime"
+	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
+	"github.com/ipld/go-ipld-prime/multicodec"
+	"github.com/ipld/go-ipld-prime/traversal"
+	"github.com/multiformats/go-multihash"
+
+	dagcosmos "github.com/vulcanize/go-codec-dagcosmos"
+)
+
+var (
+	_ ipld.Decoder = Decode
+	_ ipld.Encoder = Encode
+
+	MultiCodecType = uint64(cid.DagCBOR) // TODO: replace this with the chosen codec
+	MultiHashType  = uint64(multihash.SHA2_256)
+)
+
+func init() {
+	multicodec.RegisterDecoder(MultiCodecType, Decode)
+	multicodec.RegisterEncoder(MultiCodecType, Encode)
+}
+
+// AddSupportToChooser takes an existing node prototype chooser and subs in
+// TxTree for the tendermint tx tree multicodec code.
+func AddSupportToChooser(existing traversal.LinkTargetNodePrototypeChooser) traversal.LinkTargetNodePrototypeChooser {
+	return func(lnk ipld.Link, lnkCtx ipld.LinkContext) (ipld.NodePrototype, error) {
+		if lnk, ok := lnk.(cidlink.Link); ok && lnk.Cid.Prefix().Codec == MultiCodecType {
+			return dagcosmos.Type.MerkleTreeNode, nil
+		}
+		return existing(lnk, lnkCtx)
+	}
+}
+
+// We switched to simpler API names after v1.0.0, so keep the old names around
+// as deprecated forwarding funcs until a future v2+.
+// TODO: consider deprecating Marshal/Unmarshal too, since it's a bit
+// unnecessary to have two supported names for each API.
+
+// Deprecated: use Decode instead.
+func Decoder(na ipld.NodeAssembler, r io.Reader) error { return Decode(na, r) }
+
+// Deprecated: use Decode instead.
+func Unmarshal(na ipld.NodeAssembler, r io.Reader) error { return Decode(na, r) }
+
+// Deprecated: use Encode instead.
+func Encoder(inNode ipld.Node, w io.Writer) error { return Encode(inNode, w) }
+
+// Deprecated: use Encode instead.
+func Marshal(inNode ipld.Node, w io.Writer) error { return Encode(inNode, w) }

--- a/tx_tree/unmarshal.go
+++ b/tx_tree/unmarshal.go
@@ -1,0 +1,25 @@
+package tx_tree
+
+import (
+	"io"
+
+	"github.com/ipld/go-ipld-prime"
+
+	mt "github.com/vulcanize/go-codec-dagcosmos/merkle_tree"
+)
+
+// Decode provides an IPLD codec decode interface for Tendermint TxTree IPLDs.
+// This function is registered via the go-ipld-prime link loader for multicodec
+// code XXX when this package is invoked via init.
+// This simply wraps mt.DecodeTrieNode with the proper multicodec type
+func Decode(na ipld.NodeAssembler, in io.Reader) error {
+	return mt.DecodeTrieNode(na, in, MultiCodecType)
+}
+
+// DecodeBytes is like Decode, but it uses an input buffer directly.
+// Decode will grab or read all the bytes from an io.Reader anyway, so this can
+// save having to copy the bytes or create a bytes.Buffer.
+// This simply wraps mt.DecodeTrieNodeBytes with the proper multicodec type
+func DecodeBytes(na ipld.NodeAssembler, src []byte) error {
+	return mt.DecodeTrieNodeBytes(na, src, MultiCodecType)
+}

--- a/validator_tree/marshal.go
+++ b/validator_tree/marshal.go
@@ -1,0 +1,25 @@
+package validator_tree
+
+import (
+	"io"
+
+	"github.com/ipld/go-ipld-prime"
+
+	mt "github.com/vulcanize/go-codec-dagcosmos/merkle_tree"
+)
+
+// Encode provides an IPLD codec encode interface for Tendermint ValidatorTree IPLDs.
+// This function is registered via the go-ipld-prime link loader for multicodec
+// code XXX when this package is invoked via init.
+// This is a pure wrapping around mt.Encode to expose it from this package
+func Encode(node ipld.Node, w io.Writer) error {
+	return mt.Encode(node, w)
+}
+
+// AppendEncode is like Encode, but it uses a destination buffer directly.
+// This means less copying of bytes, and if the destination has enough capacity,
+// fewer allocations.
+// This is a pure wrapping around mt.AppendEncode to expose it from this package
+func AppendEncode(enc []byte, inNode ipld.Node) ([]byte, error) {
+	return mt.AppendEncode(enc, inNode)
+}

--- a/validator_tree/multicodec.go
+++ b/validator_tree/multicodec.go
@@ -1,0 +1,55 @@
+package validator_tree
+
+import (
+	"io"
+
+	"github.com/ipfs/go-cid"
+	"github.com/ipld/go-ipld-prime"
+	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
+	"github.com/ipld/go-ipld-prime/multicodec"
+	"github.com/ipld/go-ipld-prime/traversal"
+	"github.com/multiformats/go-multihash"
+
+	dagcosmos "github.com/vulcanize/go-codec-dagcosmos"
+)
+
+var (
+	_ ipld.Decoder = Decode
+	_ ipld.Encoder = Encode
+
+	MultiCodecType = uint64(cid.DagCBOR) // TODO: replace this with the chosen codec
+	MultiHashType  = uint64(multihash.SHA2_256)
+)
+
+func init() {
+	multicodec.RegisterDecoder(MultiCodecType, Decode)
+	multicodec.RegisterEncoder(MultiCodecType, Encode)
+}
+
+// AddSupportToChooser takes an existing node prototype chooser and subs in
+// ValidatorTree for the tendermint validator tree multicodec code.
+func AddSupportToChooser(existing traversal.LinkTargetNodePrototypeChooser) traversal.LinkTargetNodePrototypeChooser {
+	return func(lnk ipld.Link, lnkCtx ipld.LinkContext) (ipld.NodePrototype, error) {
+		if lnk, ok := lnk.(cidlink.Link); ok && lnk.Cid.Prefix().Codec == MultiCodecType {
+			return dagcosmos.Type.MerkleTreeNode, nil
+		}
+		return existing(lnk, lnkCtx)
+	}
+}
+
+// We switched to simpler API names after v1.0.0, so keep the old names around
+// as deprecated forwarding funcs until a future v2+.
+// TODO: consider deprecating Marshal/Unmarshal too, since it's a bit
+// unnecessary to have two supported names for each API.
+
+// Deprecated: use Decode instead.
+func Decoder(na ipld.NodeAssembler, r io.Reader) error { return Decode(na, r) }
+
+// Deprecated: use Decode instead.
+func Unmarshal(na ipld.NodeAssembler, r io.Reader) error { return Decode(na, r) }
+
+// Deprecated: use Encode instead.
+func Encoder(inNode ipld.Node, w io.Writer) error { return Encode(inNode, w) }
+
+// Deprecated: use Encode instead.
+func Marshal(inNode ipld.Node, w io.Writer) error { return Encode(inNode, w) }

--- a/validator_tree/unmarshal.go
+++ b/validator_tree/unmarshal.go
@@ -1,0 +1,25 @@
+package validator_tree
+
+import (
+	"io"
+
+	"github.com/ipld/go-ipld-prime"
+
+	mt "github.com/vulcanize/go-codec-dagcosmos/merkle_tree"
+)
+
+// Decode provides an IPLD codec decode interface for Tendermint ValidatorTree IPLDs.
+// This function is registered via the go-ipld-prime link loader for multicodec
+// code XXX when this package is invoked via init.
+// This simply wraps mt.DecodeTrieNode with the proper multicodec type
+func Decode(na ipld.NodeAssembler, in io.Reader) error {
+	return mt.DecodeTrieNode(na, in, MultiCodecType)
+}
+
+// DecodeBytes is like Decode, but it uses an input buffer directly.
+// Decode will grab or read all the bytes from an io.Reader anyway, so this can
+// save having to copy the bytes or create a bytes.Buffer.
+// This simply wraps mt.DecodeTrieNodeBytes with the proper multicodec type
+func DecodeBytes(na ipld.NodeAssembler, src []byte) error {
+	return mt.DecodeTrieNodeBytes(na, src, MultiCodecType)
+}


### PR DESCRIPTION
Currently this doesn't decode the leaf values of a header tree or part tree. I still need to figure out the best way to handle trees composed of header fields and arbitrarily fragmented blocks.

A header tree is a merkle tree with 14 leaf nodes, these nodes store the 14 protobuf encoded fields of a header in order. As such we only know how to handle decoding of a leaf value if we know its position in the tree, and therefore it's type (since the types otherwise cannot be distinguished e.g. can't tell apart a merkle root for a CommitTree vs a TxTree).

A part tree is a tree composed of the fragments of a protobuf encoded Block. The block bytes are split based on an arbitrary index size, meaning individual fields of the Block will be split across separate leaf nodes (it is not possible to map a leaf node value to a type). As such it is impossible to decode the values without collecting them all, concatenating the bytes in the order they appear in the leaf nodes, and unmarshalling the restored byte array into the Tendermint Block protobuf type.

Towards #3 