### PR TITLE
SMT marshaller and unmarshaller

### DIFF
--- a/gen.go
+++ b/gen.go
@@ -656,8 +656,8 @@ func accumulateChainTypes(ts *schema.TypeSystem) {
 	))
 	ts.Accumulate(schema.SpawnStruct("MerkleTreeInnerNode",
 		[]schema.StructField{
-			schema.SpawnStructField("Left", "Link", false, false),
-			schema.SpawnStructField("Right", "Link", false, false),
+			schema.SpawnStructField("Left", "Link", false, true),
+			schema.SpawnStructField("Right", "Link", false, true),
 		},
 		schema.SpawnStructRepresentationMap(nil),
 	))
@@ -715,8 +715,8 @@ func accumulateCosmosDataStructures(ts *schema.TypeSystem) {
 
 		# IAVLInnerNode represents an inner node in an IAVL Tree.
 		type IAVLInnerNode struct {
-			Left      IAVLNodeCID
-			Right     IAVLNodeCID
+			Left      nullable IAVLNodeCID
+			Right     nullable IAVLNodeCID
 			Version   Int
 			Size      Int
 			Height    Int
@@ -747,8 +747,8 @@ func accumulateCosmosDataStructures(ts *schema.TypeSystem) {
 	))
 	ts.Accumulate(schema.SpawnStruct("IAVLInnerNode",
 		[]schema.StructField{
-			schema.SpawnStructField("Left", "Link", false, false),
-			schema.SpawnStructField("Right", "Link", false, false),
+			schema.SpawnStructField("Left", "Link", false, true),
+			schema.SpawnStructField("Right", "Link", false, true),
 			schema.SpawnStructField("Version", "Int", false, false),
 			schema.SpawnStructField("Size", "Int", false, false),
 			schema.SpawnStructField("Height", "Int", false, false),
@@ -782,8 +782,8 @@ func accumulateCosmosDataStructures(ts *schema.TypeSystem) {
 
 		# SMTInnerNode contains two byte arrays which contain the hashes which link its two child nodes.
 		type SMTInnerNode struct {
-			Left SMTNodeCID
-			Right SMTNodeCID
+			Left nullable SMTNodeCID
+			Right nullable SMTNodeCID
 		}
 
 		# SMTLeafNode contains two byte arrays which contain path and value
@@ -808,8 +808,8 @@ func accumulateCosmosDataStructures(ts *schema.TypeSystem) {
 	))
 	ts.Accumulate(schema.SpawnStruct("SMTInnerNode",
 		[]schema.StructField{
-			schema.SpawnStructField("Left", "Link", false, false),
-			schema.SpawnStructField("Right", "Link", false, false),
+			schema.SpawnStructField("Left", "Link", false, true),
+			schema.SpawnStructField("Right", "Link", false, true),
 		},
 		schema.SpawnStructRepresentationMap(nil),
 	))

--- a/ipldsch_satisfaction.go
+++ b/ipldsch_satisfaction.go
@@ -13392,10 +13392,10 @@ var _ ipld.Node = &_HexBytes__Repr{}
 type _HexBytes__ReprPrototype = _HexBytes__Prototype
 type _HexBytes__ReprAssembler = _HexBytes__Assembler
 
-func (n _IAVLInnerNode) FieldLeft() Link {
+func (n _IAVLInnerNode) FieldLeft() MaybeLink {
 	return &n.Left
 }
-func (n _IAVLInnerNode) FieldRight() Link {
+func (n _IAVLInnerNode) FieldRight() MaybeLink {
 	return &n.Right
 }
 func (n _IAVLInnerNode) FieldVersion() Int {
@@ -13458,9 +13458,15 @@ func (IAVLInnerNode) Kind() ipld.Kind {
 func (n IAVLInnerNode) LookupByString(key string) (ipld.Node, error) {
 	switch key {
 	case "Left":
-		return &n.Left, nil
+		if n.Left.m == schema.Maybe_Null {
+			return ipld.Null, nil
+		}
+		return n.Left.v, nil
 	case "Right":
-		return &n.Right, nil
+		if n.Right.m == schema.Maybe_Null {
+			return ipld.Null, nil
+		}
+		return n.Right.v, nil
 	case "Version":
 		return &n.Version, nil
 	case "Size":
@@ -13500,10 +13506,18 @@ func (itr *_IAVLInnerNode__MapItr) Next() (k ipld.Node, v ipld.Node, _ error) {
 	switch itr.idx {
 	case 0:
 		k = &fieldName__IAVLInnerNode_Left
-		v = &itr.n.Left
+		if itr.n.Left.m == schema.Maybe_Null {
+			v = ipld.Null
+			break
+		}
+		v = itr.n.Left.v
 	case 1:
 		k = &fieldName__IAVLInnerNode_Right
-		v = &itr.n.Right
+		if itr.n.Right.m == schema.Maybe_Null {
+			v = ipld.Null
+			break
+		}
+		v = itr.n.Right.v
 	case 2:
 		k = &fieldName__IAVLInnerNode_Version
 		v = &itr.n.Version
@@ -13707,20 +13721,24 @@ func (_IAVLInnerNode__Assembler) Prototype() ipld.NodePrototype {
 func (ma *_IAVLInnerNode__Assembler) valueFinishTidy() bool {
 	switch ma.f {
 	case 0:
-		switch ma.cm {
+		switch ma.w.Left.m {
+		case schema.Maybe_Null:
+			ma.state = maState_initial
+			return true
 		case schema.Maybe_Value:
-			ma.ca_Left.w = nil
-			ma.cm = schema.Maybe_Absent
+			ma.w.Left.v = ma.ca_Left.w
 			ma.state = maState_initial
 			return true
 		default:
 			return false
 		}
 	case 1:
-		switch ma.cm {
+		switch ma.w.Right.m {
+		case schema.Maybe_Null:
+			ma.state = maState_initial
+			return true
 		case schema.Maybe_Value:
-			ma.ca_Right.w = nil
-			ma.cm = schema.Maybe_Absent
+			ma.w.Right.v = ma.ca_Right.w
 			ma.state = maState_initial
 			return true
 		default:
@@ -13783,8 +13801,9 @@ func (ma *_IAVLInnerNode__Assembler) AssembleEntry(k string) (ipld.NodeAssembler
 		ma.s += fieldBit__IAVLInnerNode_Left
 		ma.state = maState_midValue
 		ma.f = 0
-		ma.ca_Left.w = &ma.w.Left
-		ma.ca_Left.m = &ma.cm
+		ma.ca_Left.w = ma.w.Left.v
+		ma.ca_Left.m = &ma.w.Left.m
+		ma.w.Left.m = allowNull
 		return &ma.ca_Left, nil
 	case "Right":
 		if ma.s&fieldBit__IAVLInnerNode_Right != 0 {
@@ -13793,8 +13812,9 @@ func (ma *_IAVLInnerNode__Assembler) AssembleEntry(k string) (ipld.NodeAssembler
 		ma.s += fieldBit__IAVLInnerNode_Right
 		ma.state = maState_midValue
 		ma.f = 1
-		ma.ca_Right.w = &ma.w.Right
-		ma.ca_Right.m = &ma.cm
+		ma.ca_Right.w = ma.w.Right.v
+		ma.ca_Right.m = &ma.w.Right.m
+		ma.w.Right.m = allowNull
 		return &ma.ca_Right, nil
 	case "Version":
 		if ma.s&fieldBit__IAVLInnerNode_Version != 0 {
@@ -13863,12 +13883,14 @@ func (ma *_IAVLInnerNode__Assembler) AssembleValue() ipld.NodeAssembler {
 	ma.state = maState_midValue
 	switch ma.f {
 	case 0:
-		ma.ca_Left.w = &ma.w.Left
-		ma.ca_Left.m = &ma.cm
+		ma.ca_Left.w = ma.w.Left.v
+		ma.ca_Left.m = &ma.w.Left.m
+		ma.w.Left.m = allowNull
 		return &ma.ca_Left
 	case 1:
-		ma.ca_Right.w = &ma.w.Right
-		ma.ca_Right.m = &ma.cm
+		ma.ca_Right.w = ma.w.Right.v
+		ma.ca_Right.m = &ma.w.Right.m
+		ma.w.Right.m = allowNull
 		return &ma.ca_Right
 	case 2:
 		ma.ca_Version.w = &ma.w.Version
@@ -13903,12 +13925,6 @@ func (ma *_IAVLInnerNode__Assembler) Finish() error {
 	}
 	if ma.s&fieldBits__IAVLInnerNode_sufficient != fieldBits__IAVLInnerNode_sufficient {
 		err := ipld.ErrMissingRequiredField{Missing: make([]string, 0)}
-		if ma.s&fieldBit__IAVLInnerNode_Left == 0 {
-			err.Missing = append(err.Missing, "Left")
-		}
-		if ma.s&fieldBit__IAVLInnerNode_Right == 0 {
-			err.Missing = append(err.Missing, "Right")
-		}
 		if ma.s&fieldBit__IAVLInnerNode_Version == 0 {
 			err.Missing = append(err.Missing, "Version")
 		}
@@ -14036,9 +14052,15 @@ func (_IAVLInnerNode__Repr) Kind() ipld.Kind {
 func (n *_IAVLInnerNode__Repr) LookupByString(key string) (ipld.Node, error) {
 	switch key {
 	case "Left":
-		return n.Left.Representation(), nil
+		if n.Left.m == schema.Maybe_Null {
+			return ipld.Null, nil
+		}
+		return n.Left.v.Representation(), nil
 	case "Right":
-		return n.Right.Representation(), nil
+		if n.Right.m == schema.Maybe_Null {
+			return ipld.Null, nil
+		}
+		return n.Right.v.Representation(), nil
 	case "Version":
 		return n.Version.Representation(), nil
 	case "Size":
@@ -14078,10 +14100,18 @@ func (itr *_IAVLInnerNode__ReprMapItr) Next() (k ipld.Node, v ipld.Node, _ error
 	switch itr.idx {
 	case 0:
 		k = &fieldName__IAVLInnerNode_Left_serial
-		v = itr.n.Left.Representation()
+		if itr.n.Left.m == schema.Maybe_Null {
+			v = ipld.Null
+			break
+		}
+		v = itr.n.Left.v.Representation()
 	case 1:
 		k = &fieldName__IAVLInnerNode_Right_serial
-		v = itr.n.Right.Representation()
+		if itr.n.Right.m == schema.Maybe_Null {
+			v = ipld.Null
+			break
+		}
+		v = itr.n.Right.v.Representation()
 	case 2:
 		k = &fieldName__IAVLInnerNode_Version_serial
 		v = itr.n.Version.Representation()
@@ -14275,18 +14305,24 @@ func (_IAVLInnerNode__ReprAssembler) Prototype() ipld.NodePrototype {
 func (ma *_IAVLInnerNode__ReprAssembler) valueFinishTidy() bool {
 	switch ma.f {
 	case 0:
-		switch ma.cm {
+		switch ma.w.Left.m {
+		case schema.Maybe_Null:
+			ma.state = maState_initial
+			return true
 		case schema.Maybe_Value:
-			ma.cm = schema.Maybe_Absent
+			ma.w.Left.v = ma.ca_Left.w
 			ma.state = maState_initial
 			return true
 		default:
 			return false
 		}
 	case 1:
-		switch ma.cm {
+		switch ma.w.Right.m {
+		case schema.Maybe_Null:
+			ma.state = maState_initial
+			return true
 		case schema.Maybe_Value:
-			ma.cm = schema.Maybe_Absent
+			ma.w.Right.v = ma.ca_Right.w
 			ma.state = maState_initial
 			return true
 		default:
@@ -14346,8 +14382,9 @@ func (ma *_IAVLInnerNode__ReprAssembler) AssembleEntry(k string) (ipld.NodeAssem
 		ma.s += fieldBit__IAVLInnerNode_Left
 		ma.state = maState_midValue
 		ma.f = 0
-		ma.ca_Left.w = &ma.w.Left
-		ma.ca_Left.m = &ma.cm
+		ma.ca_Left.w = ma.w.Left.v
+		ma.ca_Left.m = &ma.w.Left.m
+		ma.w.Left.m = allowNull
 		return &ma.ca_Left, nil
 	case "Right":
 		if ma.s&fieldBit__IAVLInnerNode_Right != 0 {
@@ -14356,8 +14393,9 @@ func (ma *_IAVLInnerNode__ReprAssembler) AssembleEntry(k string) (ipld.NodeAssem
 		ma.s += fieldBit__IAVLInnerNode_Right
 		ma.state = maState_midValue
 		ma.f = 1
-		ma.ca_Right.w = &ma.w.Right
-		ma.ca_Right.m = &ma.cm
+		ma.ca_Right.w = ma.w.Right.v
+		ma.ca_Right.m = &ma.w.Right.m
+		ma.w.Right.m = allowNull
 		return &ma.ca_Right, nil
 	case "Version":
 		if ma.s&fieldBit__IAVLInnerNode_Version != 0 {
@@ -14427,12 +14465,14 @@ func (ma *_IAVLInnerNode__ReprAssembler) AssembleValue() ipld.NodeAssembler {
 	ma.state = maState_midValue
 	switch ma.f {
 	case 0:
-		ma.ca_Left.w = &ma.w.Left
-		ma.ca_Left.m = &ma.cm
+		ma.ca_Left.w = ma.w.Left.v
+		ma.ca_Left.m = &ma.w.Left.m
+		ma.w.Left.m = allowNull
 		return &ma.ca_Left
 	case 1:
-		ma.ca_Right.w = &ma.w.Right
-		ma.ca_Right.m = &ma.cm
+		ma.ca_Right.w = ma.w.Right.v
+		ma.ca_Right.m = &ma.w.Right.m
+		ma.w.Right.m = allowNull
 		return &ma.ca_Right
 	case 2:
 		ma.ca_Version.w = &ma.w.Version
@@ -14467,12 +14507,6 @@ func (ma *_IAVLInnerNode__ReprAssembler) Finish() error {
 	}
 	if ma.s&fieldBits__IAVLInnerNode_sufficient != fieldBits__IAVLInnerNode_sufficient {
 		err := ipld.ErrMissingRequiredField{Missing: make([]string, 0)}
-		if ma.s&fieldBit__IAVLInnerNode_Left == 0 {
-			err.Missing = append(err.Missing, "Left")
-		}
-		if ma.s&fieldBit__IAVLInnerNode_Right == 0 {
-			err.Missing = append(err.Missing, "Right")
-		}
 		if ma.s&fieldBit__IAVLInnerNode_Version == 0 {
 			err.Missing = append(err.Missing, "Version")
 		}
@@ -19210,10 +19244,10 @@ var _ ipld.Node = &_Link__Repr{}
 type _Link__ReprPrototype = _Link__Prototype
 type _Link__ReprAssembler = _Link__Assembler
 
-func (n _MerkleTreeInnerNode) FieldLeft() Link {
+func (n _MerkleTreeInnerNode) FieldLeft() MaybeLink {
 	return &n.Left
 }
-func (n _MerkleTreeInnerNode) FieldRight() Link {
+func (n _MerkleTreeInnerNode) FieldRight() MaybeLink {
 	return &n.Right
 }
 
@@ -19264,9 +19298,15 @@ func (MerkleTreeInnerNode) Kind() ipld.Kind {
 func (n MerkleTreeInnerNode) LookupByString(key string) (ipld.Node, error) {
 	switch key {
 	case "Left":
-		return &n.Left, nil
+		if n.Left.m == schema.Maybe_Null {
+			return ipld.Null, nil
+		}
+		return n.Left.v, nil
 	case "Right":
-		return &n.Right, nil
+		if n.Right.m == schema.Maybe_Null {
+			return ipld.Null, nil
+		}
+		return n.Right.v, nil
 	default:
 		return nil, schema.ErrNoSuchField{Type: nil /*TODO*/, Field: ipld.PathSegmentOfString(key)}
 	}
@@ -19300,10 +19340,18 @@ func (itr *_MerkleTreeInnerNode__MapItr) Next() (k ipld.Node, v ipld.Node, _ err
 	switch itr.idx {
 	case 0:
 		k = &fieldName__MerkleTreeInnerNode_Left
-		v = &itr.n.Left
+		if itr.n.Left.m == schema.Maybe_Null {
+			v = ipld.Null
+			break
+		}
+		v = itr.n.Left.v
 	case 1:
 		k = &fieldName__MerkleTreeInnerNode_Right
-		v = &itr.n.Right
+		if itr.n.Right.m == schema.Maybe_Null {
+			v = ipld.Null
+			break
+		}
+		v = itr.n.Right.v
 	default:
 		panic("unreachable")
 	}
@@ -19489,20 +19537,24 @@ func (_MerkleTreeInnerNode__Assembler) Prototype() ipld.NodePrototype {
 func (ma *_MerkleTreeInnerNode__Assembler) valueFinishTidy() bool {
 	switch ma.f {
 	case 0:
-		switch ma.cm {
+		switch ma.w.Left.m {
+		case schema.Maybe_Null:
+			ma.state = maState_initial
+			return true
 		case schema.Maybe_Value:
-			ma.ca_Left.w = nil
-			ma.cm = schema.Maybe_Absent
+			ma.w.Left.v = ma.ca_Left.w
 			ma.state = maState_initial
 			return true
 		default:
 			return false
 		}
 	case 1:
-		switch ma.cm {
+		switch ma.w.Right.m {
+		case schema.Maybe_Null:
+			ma.state = maState_initial
+			return true
 		case schema.Maybe_Value:
-			ma.ca_Right.w = nil
-			ma.cm = schema.Maybe_Absent
+			ma.w.Right.v = ma.ca_Right.w
 			ma.state = maState_initial
 			return true
 		default:
@@ -19535,8 +19587,9 @@ func (ma *_MerkleTreeInnerNode__Assembler) AssembleEntry(k string) (ipld.NodeAss
 		ma.s += fieldBit__MerkleTreeInnerNode_Left
 		ma.state = maState_midValue
 		ma.f = 0
-		ma.ca_Left.w = &ma.w.Left
-		ma.ca_Left.m = &ma.cm
+		ma.ca_Left.w = ma.w.Left.v
+		ma.ca_Left.m = &ma.w.Left.m
+		ma.w.Left.m = allowNull
 		return &ma.ca_Left, nil
 	case "Right":
 		if ma.s&fieldBit__MerkleTreeInnerNode_Right != 0 {
@@ -19545,8 +19598,9 @@ func (ma *_MerkleTreeInnerNode__Assembler) AssembleEntry(k string) (ipld.NodeAss
 		ma.s += fieldBit__MerkleTreeInnerNode_Right
 		ma.state = maState_midValue
 		ma.f = 1
-		ma.ca_Right.w = &ma.w.Right
-		ma.ca_Right.m = &ma.cm
+		ma.ca_Right.w = ma.w.Right.v
+		ma.ca_Right.m = &ma.w.Right.m
+		ma.w.Right.m = allowNull
 		return &ma.ca_Right, nil
 	}
 	return nil, ipld.ErrInvalidKey{TypeName: "dagcosmos.MerkleTreeInnerNode", Key: &_String{k}}
@@ -19585,12 +19639,14 @@ func (ma *_MerkleTreeInnerNode__Assembler) AssembleValue() ipld.NodeAssembler {
 	ma.state = maState_midValue
 	switch ma.f {
 	case 0:
-		ma.ca_Left.w = &ma.w.Left
-		ma.ca_Left.m = &ma.cm
+		ma.ca_Left.w = ma.w.Left.v
+		ma.ca_Left.m = &ma.w.Left.m
+		ma.w.Left.m = allowNull
 		return &ma.ca_Left
 	case 1:
-		ma.ca_Right.w = &ma.w.Right
-		ma.ca_Right.m = &ma.cm
+		ma.ca_Right.w = ma.w.Right.v
+		ma.ca_Right.m = &ma.w.Right.m
+		ma.w.Right.m = allowNull
 		return &ma.ca_Right
 	default:
 		panic("unreachable")
@@ -19613,12 +19669,6 @@ func (ma *_MerkleTreeInnerNode__Assembler) Finish() error {
 	}
 	if ma.s&fieldBits__MerkleTreeInnerNode_sufficient != fieldBits__MerkleTreeInnerNode_sufficient {
 		err := ipld.ErrMissingRequiredField{Missing: make([]string, 0)}
-		if ma.s&fieldBit__MerkleTreeInnerNode_Left == 0 {
-			err.Missing = append(err.Missing, "Left")
-		}
-		if ma.s&fieldBit__MerkleTreeInnerNode_Right == 0 {
-			err.Missing = append(err.Missing, "Right")
-		}
 		return err
 	}
 	ma.state = maState_finished
@@ -19713,9 +19763,15 @@ func (_MerkleTreeInnerNode__Repr) Kind() ipld.Kind {
 func (n *_MerkleTreeInnerNode__Repr) LookupByString(key string) (ipld.Node, error) {
 	switch key {
 	case "Left":
-		return n.Left.Representation(), nil
+		if n.Left.m == schema.Maybe_Null {
+			return ipld.Null, nil
+		}
+		return n.Left.v.Representation(), nil
 	case "Right":
-		return n.Right.Representation(), nil
+		if n.Right.m == schema.Maybe_Null {
+			return ipld.Null, nil
+		}
+		return n.Right.v.Representation(), nil
 	default:
 		return nil, schema.ErrNoSuchField{Type: nil /*TODO*/, Field: ipld.PathSegmentOfString(key)}
 	}
@@ -19749,10 +19805,18 @@ func (itr *_MerkleTreeInnerNode__ReprMapItr) Next() (k ipld.Node, v ipld.Node, _
 	switch itr.idx {
 	case 0:
 		k = &fieldName__MerkleTreeInnerNode_Left_serial
-		v = itr.n.Left.Representation()
+		if itr.n.Left.m == schema.Maybe_Null {
+			v = ipld.Null
+			break
+		}
+		v = itr.n.Left.v.Representation()
 	case 1:
 		k = &fieldName__MerkleTreeInnerNode_Right_serial
-		v = itr.n.Right.Representation()
+		if itr.n.Right.m == schema.Maybe_Null {
+			v = ipld.Null
+			break
+		}
+		v = itr.n.Right.v.Representation()
 	default:
 		panic("unreachable")
 	}
@@ -19931,18 +19995,24 @@ func (_MerkleTreeInnerNode__ReprAssembler) Prototype() ipld.NodePrototype {
 func (ma *_MerkleTreeInnerNode__ReprAssembler) valueFinishTidy() bool {
 	switch ma.f {
 	case 0:
-		switch ma.cm {
+		switch ma.w.Left.m {
+		case schema.Maybe_Null:
+			ma.state = maState_initial
+			return true
 		case schema.Maybe_Value:
-			ma.cm = schema.Maybe_Absent
+			ma.w.Left.v = ma.ca_Left.w
 			ma.state = maState_initial
 			return true
 		default:
 			return false
 		}
 	case 1:
-		switch ma.cm {
+		switch ma.w.Right.m {
+		case schema.Maybe_Null:
+			ma.state = maState_initial
+			return true
 		case schema.Maybe_Value:
-			ma.cm = schema.Maybe_Absent
+			ma.w.Right.v = ma.ca_Right.w
 			ma.state = maState_initial
 			return true
 		default:
@@ -19975,8 +20045,9 @@ func (ma *_MerkleTreeInnerNode__ReprAssembler) AssembleEntry(k string) (ipld.Nod
 		ma.s += fieldBit__MerkleTreeInnerNode_Left
 		ma.state = maState_midValue
 		ma.f = 0
-		ma.ca_Left.w = &ma.w.Left
-		ma.ca_Left.m = &ma.cm
+		ma.ca_Left.w = ma.w.Left.v
+		ma.ca_Left.m = &ma.w.Left.m
+		ma.w.Left.m = allowNull
 		return &ma.ca_Left, nil
 	case "Right":
 		if ma.s&fieldBit__MerkleTreeInnerNode_Right != 0 {
@@ -19985,8 +20056,9 @@ func (ma *_MerkleTreeInnerNode__ReprAssembler) AssembleEntry(k string) (ipld.Nod
 		ma.s += fieldBit__MerkleTreeInnerNode_Right
 		ma.state = maState_midValue
 		ma.f = 1
-		ma.ca_Right.w = &ma.w.Right
-		ma.ca_Right.m = &ma.cm
+		ma.ca_Right.w = ma.w.Right.v
+		ma.ca_Right.m = &ma.w.Right.m
+		ma.w.Right.m = allowNull
 		return &ma.ca_Right, nil
 	default:
 	}
@@ -20026,12 +20098,14 @@ func (ma *_MerkleTreeInnerNode__ReprAssembler) AssembleValue() ipld.NodeAssemble
 	ma.state = maState_midValue
 	switch ma.f {
 	case 0:
-		ma.ca_Left.w = &ma.w.Left
-		ma.ca_Left.m = &ma.cm
+		ma.ca_Left.w = ma.w.Left.v
+		ma.ca_Left.m = &ma.w.Left.m
+		ma.w.Left.m = allowNull
 		return &ma.ca_Left
 	case 1:
-		ma.ca_Right.w = &ma.w.Right
-		ma.ca_Right.m = &ma.cm
+		ma.ca_Right.w = ma.w.Right.v
+		ma.ca_Right.m = &ma.w.Right.m
+		ma.w.Right.m = allowNull
 		return &ma.ca_Right
 	default:
 		panic("unreachable")
@@ -20054,12 +20128,6 @@ func (ma *_MerkleTreeInnerNode__ReprAssembler) Finish() error {
 	}
 	if ma.s&fieldBits__MerkleTreeInnerNode_sufficient != fieldBits__MerkleTreeInnerNode_sufficient {
 		err := ipld.ErrMissingRequiredField{Missing: make([]string, 0)}
-		if ma.s&fieldBit__MerkleTreeInnerNode_Left == 0 {
-			err.Missing = append(err.Missing, "Left")
-		}
-		if ma.s&fieldBit__MerkleTreeInnerNode_Right == 0 {
-			err.Missing = append(err.Missing, "Right")
-		}
 		return err
 	}
 	ma.state = maState_finished
@@ -21450,7 +21518,7 @@ func (n MerkleTreeNode) Representation() ipld.Node {
 type _MerkleTreeNode__Repr _MerkleTreeNode
 
 var (
-	memberName__MerkleTreeNode_MerkleTreeInnerNode_serial = _String{"root"}
+	memberName__MerkleTreeNode_MerkleTreeInnerNode_serial = _String{"inner"}
 	memberName__MerkleTreeNode_MerkleTreeLeafNode_serial  = _String{"leaf"}
 )
 var _ ipld.Node = &_MerkleTreeNode__Repr{}
@@ -21718,7 +21786,7 @@ func (ma *_MerkleTreeNode__ReprAssembler) AssembleEntry(k string) (ipld.NodeAsse
 		return nil, schema.ErrNotUnionStructure{TypeName: "dagcosmos.MerkleTreeNode.Repr", Detail: "cannot add another entry -- a union can only contain one thing!"}
 	}
 	switch k {
-	case "inner":
+	case "root":
 		ma.state = maState_midValue
 		ma.ca = 1
 		ma.w.tag = 1
@@ -28407,10 +28475,10 @@ func (_ResponseDeliverTx__ReprKeyAssembler) Prototype() ipld.NodePrototype {
 	return _String__Prototype{}
 }
 
-func (n _SMTInnerNode) FieldLeft() Link {
+func (n _SMTInnerNode) FieldLeft() MaybeLink {
 	return &n.Left
 }
-func (n _SMTInnerNode) FieldRight() Link {
+func (n _SMTInnerNode) FieldRight() MaybeLink {
 	return &n.Right
 }
 
@@ -28461,9 +28529,15 @@ func (SMTInnerNode) Kind() ipld.Kind {
 func (n SMTInnerNode) LookupByString(key string) (ipld.Node, error) {
 	switch key {
 	case "Left":
-		return &n.Left, nil
+		if n.Left.m == schema.Maybe_Null {
+			return ipld.Null, nil
+		}
+		return n.Left.v, nil
 	case "Right":
-		return &n.Right, nil
+		if n.Right.m == schema.Maybe_Null {
+			return ipld.Null, nil
+		}
+		return n.Right.v, nil
 	default:
 		return nil, schema.ErrNoSuchField{Type: nil /*TODO*/, Field: ipld.PathSegmentOfString(key)}
 	}
@@ -28497,10 +28571,18 @@ func (itr *_SMTInnerNode__MapItr) Next() (k ipld.Node, v ipld.Node, _ error) {
 	switch itr.idx {
 	case 0:
 		k = &fieldName__SMTInnerNode_Left
-		v = &itr.n.Left
+		if itr.n.Left.m == schema.Maybe_Null {
+			v = ipld.Null
+			break
+		}
+		v = itr.n.Left.v
 	case 1:
 		k = &fieldName__SMTInnerNode_Right
-		v = &itr.n.Right
+		if itr.n.Right.m == schema.Maybe_Null {
+			v = ipld.Null
+			break
+		}
+		v = itr.n.Right.v
 	default:
 		panic("unreachable")
 	}
@@ -28686,20 +28768,24 @@ func (_SMTInnerNode__Assembler) Prototype() ipld.NodePrototype {
 func (ma *_SMTInnerNode__Assembler) valueFinishTidy() bool {
 	switch ma.f {
 	case 0:
-		switch ma.cm {
+		switch ma.w.Left.m {
+		case schema.Maybe_Null:
+			ma.state = maState_initial
+			return true
 		case schema.Maybe_Value:
-			ma.ca_Left.w = nil
-			ma.cm = schema.Maybe_Absent
+			ma.w.Left.v = ma.ca_Left.w
 			ma.state = maState_initial
 			return true
 		default:
 			return false
 		}
 	case 1:
-		switch ma.cm {
+		switch ma.w.Right.m {
+		case schema.Maybe_Null:
+			ma.state = maState_initial
+			return true
 		case schema.Maybe_Value:
-			ma.ca_Right.w = nil
-			ma.cm = schema.Maybe_Absent
+			ma.w.Right.v = ma.ca_Right.w
 			ma.state = maState_initial
 			return true
 		default:
@@ -28732,8 +28818,9 @@ func (ma *_SMTInnerNode__Assembler) AssembleEntry(k string) (ipld.NodeAssembler,
 		ma.s += fieldBit__SMTInnerNode_Left
 		ma.state = maState_midValue
 		ma.f = 0
-		ma.ca_Left.w = &ma.w.Left
-		ma.ca_Left.m = &ma.cm
+		ma.ca_Left.w = ma.w.Left.v
+		ma.ca_Left.m = &ma.w.Left.m
+		ma.w.Left.m = allowNull
 		return &ma.ca_Left, nil
 	case "Right":
 		if ma.s&fieldBit__SMTInnerNode_Right != 0 {
@@ -28742,8 +28829,9 @@ func (ma *_SMTInnerNode__Assembler) AssembleEntry(k string) (ipld.NodeAssembler,
 		ma.s += fieldBit__SMTInnerNode_Right
 		ma.state = maState_midValue
 		ma.f = 1
-		ma.ca_Right.w = &ma.w.Right
-		ma.ca_Right.m = &ma.cm
+		ma.ca_Right.w = ma.w.Right.v
+		ma.ca_Right.m = &ma.w.Right.m
+		ma.w.Right.m = allowNull
 		return &ma.ca_Right, nil
 	}
 	return nil, ipld.ErrInvalidKey{TypeName: "dagcosmos.SMTInnerNode", Key: &_String{k}}
@@ -28782,12 +28870,14 @@ func (ma *_SMTInnerNode__Assembler) AssembleValue() ipld.NodeAssembler {
 	ma.state = maState_midValue
 	switch ma.f {
 	case 0:
-		ma.ca_Left.w = &ma.w.Left
-		ma.ca_Left.m = &ma.cm
+		ma.ca_Left.w = ma.w.Left.v
+		ma.ca_Left.m = &ma.w.Left.m
+		ma.w.Left.m = allowNull
 		return &ma.ca_Left
 	case 1:
-		ma.ca_Right.w = &ma.w.Right
-		ma.ca_Right.m = &ma.cm
+		ma.ca_Right.w = ma.w.Right.v
+		ma.ca_Right.m = &ma.w.Right.m
+		ma.w.Right.m = allowNull
 		return &ma.ca_Right
 	default:
 		panic("unreachable")
@@ -28810,12 +28900,6 @@ func (ma *_SMTInnerNode__Assembler) Finish() error {
 	}
 	if ma.s&fieldBits__SMTInnerNode_sufficient != fieldBits__SMTInnerNode_sufficient {
 		err := ipld.ErrMissingRequiredField{Missing: make([]string, 0)}
-		if ma.s&fieldBit__SMTInnerNode_Left == 0 {
-			err.Missing = append(err.Missing, "Left")
-		}
-		if ma.s&fieldBit__SMTInnerNode_Right == 0 {
-			err.Missing = append(err.Missing, "Right")
-		}
 		return err
 	}
 	ma.state = maState_finished
@@ -28910,9 +28994,15 @@ func (_SMTInnerNode__Repr) Kind() ipld.Kind {
 func (n *_SMTInnerNode__Repr) LookupByString(key string) (ipld.Node, error) {
 	switch key {
 	case "Left":
-		return n.Left.Representation(), nil
+		if n.Left.m == schema.Maybe_Null {
+			return ipld.Null, nil
+		}
+		return n.Left.v.Representation(), nil
 	case "Right":
-		return n.Right.Representation(), nil
+		if n.Right.m == schema.Maybe_Null {
+			return ipld.Null, nil
+		}
+		return n.Right.v.Representation(), nil
 	default:
 		return nil, schema.ErrNoSuchField{Type: nil /*TODO*/, Field: ipld.PathSegmentOfString(key)}
 	}
@@ -28946,10 +29036,18 @@ func (itr *_SMTInnerNode__ReprMapItr) Next() (k ipld.Node, v ipld.Node, _ error)
 	switch itr.idx {
 	case 0:
 		k = &fieldName__SMTInnerNode_Left_serial
-		v = itr.n.Left.Representation()
+		if itr.n.Left.m == schema.Maybe_Null {
+			v = ipld.Null
+			break
+		}
+		v = itr.n.Left.v.Representation()
 	case 1:
 		k = &fieldName__SMTInnerNode_Right_serial
-		v = itr.n.Right.Representation()
+		if itr.n.Right.m == schema.Maybe_Null {
+			v = ipld.Null
+			break
+		}
+		v = itr.n.Right.v.Representation()
 	default:
 		panic("unreachable")
 	}
@@ -29128,18 +29226,24 @@ func (_SMTInnerNode__ReprAssembler) Prototype() ipld.NodePrototype {
 func (ma *_SMTInnerNode__ReprAssembler) valueFinishTidy() bool {
 	switch ma.f {
 	case 0:
-		switch ma.cm {
+		switch ma.w.Left.m {
+		case schema.Maybe_Null:
+			ma.state = maState_initial
+			return true
 		case schema.Maybe_Value:
-			ma.cm = schema.Maybe_Absent
+			ma.w.Left.v = ma.ca_Left.w
 			ma.state = maState_initial
 			return true
 		default:
 			return false
 		}
 	case 1:
-		switch ma.cm {
+		switch ma.w.Right.m {
+		case schema.Maybe_Null:
+			ma.state = maState_initial
+			return true
 		case schema.Maybe_Value:
-			ma.cm = schema.Maybe_Absent
+			ma.w.Right.v = ma.ca_Right.w
 			ma.state = maState_initial
 			return true
 		default:
@@ -29172,8 +29276,9 @@ func (ma *_SMTInnerNode__ReprAssembler) AssembleEntry(k string) (ipld.NodeAssemb
 		ma.s += fieldBit__SMTInnerNode_Left
 		ma.state = maState_midValue
 		ma.f = 0
-		ma.ca_Left.w = &ma.w.Left
-		ma.ca_Left.m = &ma.cm
+		ma.ca_Left.w = ma.w.Left.v
+		ma.ca_Left.m = &ma.w.Left.m
+		ma.w.Left.m = allowNull
 		return &ma.ca_Left, nil
 	case "Right":
 		if ma.s&fieldBit__SMTInnerNode_Right != 0 {
@@ -29182,8 +29287,9 @@ func (ma *_SMTInnerNode__ReprAssembler) AssembleEntry(k string) (ipld.NodeAssemb
 		ma.s += fieldBit__SMTInnerNode_Right
 		ma.state = maState_midValue
 		ma.f = 1
-		ma.ca_Right.w = &ma.w.Right
-		ma.ca_Right.m = &ma.cm
+		ma.ca_Right.w = ma.w.Right.v
+		ma.ca_Right.m = &ma.w.Right.m
+		ma.w.Right.m = allowNull
 		return &ma.ca_Right, nil
 	default:
 	}
@@ -29223,12 +29329,14 @@ func (ma *_SMTInnerNode__ReprAssembler) AssembleValue() ipld.NodeAssembler {
 	ma.state = maState_midValue
 	switch ma.f {
 	case 0:
-		ma.ca_Left.w = &ma.w.Left
-		ma.ca_Left.m = &ma.cm
+		ma.ca_Left.w = ma.w.Left.v
+		ma.ca_Left.m = &ma.w.Left.m
+		ma.w.Left.m = allowNull
 		return &ma.ca_Left
 	case 1:
-		ma.ca_Right.w = &ma.w.Right
-		ma.ca_Right.m = &ma.cm
+		ma.ca_Right.w = ma.w.Right.v
+		ma.ca_Right.m = &ma.w.Right.m
+		ma.w.Right.m = allowNull
 		return &ma.ca_Right
 	default:
 		panic("unreachable")
@@ -29251,12 +29359,6 @@ func (ma *_SMTInnerNode__ReprAssembler) Finish() error {
 	}
 	if ma.s&fieldBits__SMTInnerNode_sufficient != fieldBits__SMTInnerNode_sufficient {
 		err := ipld.ErrMissingRequiredField{Missing: make([]string, 0)}
-		if ma.s&fieldBit__SMTInnerNode_Left == 0 {
-			err.Missing = append(err.Missing, "Left")
-		}
-		if ma.s&fieldBit__SMTInnerNode_Right == 0 {
-			err.Missing = append(err.Missing, "Right")
-		}
 		return err
 	}
 	ma.state = maState_finished

--- a/ipldsch_types.go
+++ b/ipldsch_types.go
@@ -270,8 +270,8 @@ type _HexBytes struct{ x []byte }
 // IAVLInnerNode matches the IPLD Schema type "IAVLInnerNode".  It has Struct type-kind, and may be interrogated like map kind.
 type IAVLInnerNode = *_IAVLInnerNode
 type _IAVLInnerNode struct {
-	Left    _Link
-	Right   _Link
+	Left    _Link__Maybe
+	Right   _Link__Maybe
 	Version _Int
 	Size    _Int
 	Height  _Int
@@ -330,8 +330,8 @@ type _Link struct{ x ipld.Link }
 // MerkleTreeInnerNode matches the IPLD Schema type "MerkleTreeInnerNode".  It has Struct type-kind, and may be interrogated like map kind.
 type MerkleTreeInnerNode = *_MerkleTreeInnerNode
 type _MerkleTreeInnerNode struct {
-	Left  _Link
-	Right _Link
+	Left  _Link__Maybe
+	Right _Link__Maybe
 }
 
 // MerkleTreeLeafNode matches the IPLD Schema type "MerkleTreeLeafNode".  It has Struct type-kind, and may be interrogated like map kind.
@@ -417,8 +417,8 @@ type _ResponseDeliverTx struct {
 // SMTInnerNode matches the IPLD Schema type "SMTInnerNode".  It has Struct type-kind, and may be interrogated like map kind.
 type SMTInnerNode = *_SMTInnerNode
 type _SMTInnerNode struct {
-	Left  _Link
-	Right _Link
+	Left  _Link__Maybe
+	Right _Link__Maybe
 }
 
 // SMTLeafNode matches the IPLD Schema type "SMTLeafNode".  It has Struct type-kind, and may be interrogated like map kind.

--- a/smt/marshal.go
+++ b/smt/marshal.go
@@ -1,0 +1,152 @@
+package smt
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"fmt"
+	"io"
+
+	"github.com/ipld/go-ipld-prime"
+
+	dagcosmos "github.com/vulcanize/go-codec-dagcosmos"
+	"github.com/vulcanize/go-codec-dagcosmos/shared"
+)
+
+type NodeKind string
+
+var (
+	hasher      = sha256.New()
+	hashSize    = hasher.Size()
+	placeholder = bytes.Repeat([]byte{0}, hashSize)
+	leafPrefix  = []byte{0}
+	innerPrefix = []byte{1}
+)
+
+const (
+	INNER_NODE NodeKind = "inner"
+	LEAF_NODE  NodeKind = "leaf"
+)
+
+func (n NodeKind) String() string {
+	return string(n)
+}
+
+// Encode provides an IPLD codec encode interface for Tendermint SMT node IPLDs.
+// This function is registered via the go-ipld-prime link loader for multicodec
+// code XXXX when this package is invoked via init.
+func Encode(node ipld.Node, w io.Writer) error {
+	// 1KiB can be allocated on the stack, and covers most small nodes
+	// without having to grow the buffer and cause allocations.
+	enc := make([]byte, 0, 1024)
+
+	enc, err := AppendEncode(enc, node)
+	if err != nil {
+		return err
+	}
+	_, err = w.Write(enc)
+	return err
+}
+
+// AppendEncode is like Encode, but it uses a destination buffer directly.
+// This means less copying of bytes, and if the destination has enough capacity,
+// fewer allocations.
+func AppendEncode(enc []byte, inNode ipld.Node) ([]byte, error) {
+	// Wrap in a typed node for some basic schema form checking
+	builder := dagcosmos.Type.MerkleTreeNode.NewBuilder()
+	if err := builder.AssignNode(inNode); err != nil {
+		return nil, err
+	}
+	n := builder.Build()
+	node, kind, err := NodeAndKind(n)
+	if err != nil {
+		return nil, err
+	}
+	switch kind {
+	case INNER_NODE:
+		enc, err = packInnerNode(node)
+	case LEAF_NODE:
+		enc, err = packLeafNode(node)
+	default:
+		return nil, fmt.Errorf("IPLD node is missing the expected Union keys")
+	}
+	return enc, err
+}
+
+func packInnerNode(node ipld.Node) ([]byte, error) {
+	var leftData, rightData []byte
+	leftNode, err := node.LookupByString("Left")
+	if err != nil {
+		return nil, err
+	}
+	if leftNode.IsNull() {
+		leftData = placeholder
+	} else {
+		leftData, err = shared.PackLink(leftNode)
+		if err != nil {
+			return nil, err
+		}
+	}
+	rightNode, err := node.LookupByString("Right")
+	if err != nil {
+		return nil, err
+	}
+	if rightNode.IsNull() {
+		rightData = placeholder
+	} else {
+		rightData, err = shared.PackLink(rightNode)
+		if err != nil {
+			return nil, err
+		}
+	}
+	nodeVal := make([]byte, 0, len(innerPrefix)+len(leftData)+len(rightData))
+	nodeVal = append(nodeVal, innerPrefix...)
+	nodeVal = append(nodeVal, leftData...)
+	nodeVal = append(nodeVal, rightData...)
+	return nodeVal, nil
+}
+
+func packLeafNode(node ipld.Node) ([]byte, error) {
+	path, err := packPath(node)
+	if err != nil {
+		return nil, err
+	}
+	val, err := packValue(node)
+	if err != nil {
+		return nil, err
+	}
+	nodeVal := make([]byte, 0, len(leafPrefix)+len(path)+len(val))
+	nodeVal = append(nodeVal, leafPrefix...)
+	nodeVal = append(nodeVal, path...)
+	nodeVal = append(nodeVal, val...)
+	return nodeVal, nil
+}
+
+func packPath(node ipld.Node) ([]byte, error) {
+	pathNode, err := node.LookupByString("Path")
+	if err != nil {
+		return nil, err
+	}
+	return pathNode.AsBytes()
+}
+
+func packValue(node ipld.Node) ([]byte, error) {
+	valNode, err := node.LookupByString("Value")
+	if err != nil {
+		return nil, err
+	}
+	// at this time we are not attempting to further handle the arbitrary hash(key, value) stored here
+	return valNode.AsBytes()
+}
+
+// NodeAndKind returns the node and its kind
+func NodeAndKind(node ipld.Node) (ipld.Node, NodeKind, error) {
+	n, err := node.LookupByString(LEAF_NODE.String())
+	if err == nil {
+		return n, LEAF_NODE, nil
+	}
+	n, err = node.LookupByString(INNER_NODE.String())
+	if err == nil {
+		return n, INNER_NODE, nil
+	}
+	return nil, "", fmt.Errorf("SMT IPLD node is missing the expected keyed Union keys")
+}

--- a/smt/multicodec.go
+++ b/smt/multicodec.go
@@ -1,0 +1,55 @@
+package smt
+
+import (
+	"io"
+
+	"github.com/ipfs/go-cid"
+	"github.com/ipld/go-ipld-prime"
+	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
+	"github.com/ipld/go-ipld-prime/multicodec"
+	"github.com/ipld/go-ipld-prime/traversal"
+	"github.com/multiformats/go-multihash"
+
+	dagcosmos "github.com/vulcanize/go-codec-dagcosmos"
+)
+
+var (
+	_ ipld.Decoder = Decode
+	_ ipld.Encoder = Encode
+
+	MultiCodecType = uint64(cid.DagCBOR) // TODO: replace this with the chosen codec
+	MultiHashType  = uint64(multihash.SHA2_256)
+)
+
+func init() {
+	multicodec.RegisterDecoder(MultiCodecType, Decode)
+	multicodec.RegisterEncoder(MultiCodecType, Encode)
+}
+
+// AddSupportToChooser takes an existing node prototype chooser and subs in
+// SMTNode for the cosmos smt multicodec code.
+func AddSupportToChooser(existing traversal.LinkTargetNodePrototypeChooser) traversal.LinkTargetNodePrototypeChooser {
+	return func(lnk ipld.Link, lnkCtx ipld.LinkContext) (ipld.NodePrototype, error) {
+		if lnk, ok := lnk.(cidlink.Link); ok && lnk.Cid.Prefix().Codec == MultiCodecType {
+			return dagcosmos.Type.SMTNode, nil
+		}
+		return existing(lnk, lnkCtx)
+	}
+}
+
+// We switched to simpler API names after v1.0.0, so keep the old names around
+// as deprecated forwarding funcs until a future v2+.
+// TODO: consider deprecating Marshal/Unmarshal too, since it's a bit
+// unnecessary to have two supported names for each API.
+
+// Deprecated: use Decode instead.
+func Decoder(na ipld.NodeAssembler, r io.Reader) error { return Decode(na, r) }
+
+// Deprecated: use Decode instead.
+func Unmarshal(na ipld.NodeAssembler, r io.Reader) error { return Decode(na, r) }
+
+// Deprecated: use Encode instead.
+func Encoder(inNode ipld.Node, w io.Writer) error { return Encode(inNode, w) }
+
+// Deprecated: use Encode instead.
+func Marshal(inNode ipld.Node, w io.Writer) error { return Encode(inNode, w) }

--- a/smt/unmarshal.go
+++ b/smt/unmarshal.go
@@ -1,0 +1,142 @@
+package smt
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"io/ioutil"
+
+	"github.com/ipfs/go-cid"
+	"github.com/ipld/go-ipld-prime"
+	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
+	"github.com/multiformats/go-multihash"
+)
+
+// Decode provides an IPLD codec decode interface for Tendermint SMT nodes
+// This function is registered via the go-ipld-prime link loader for multicodec
+// code XXX when this package is invoked via init.
+func Decode(na ipld.NodeAssembler, in io.Reader) error {
+	var src []byte
+	if buf, ok := in.(interface{ Bytes() []byte }); ok {
+		src = buf.Bytes()
+	} else {
+		var err error
+		src, err = ioutil.ReadAll(in)
+		if err != nil {
+			return err
+		}
+	}
+	return DecodeBytes(na, src)
+}
+
+// DecodeBytes is like DecodeTrieNode, but it uses an input buffer directly.
+// Decode will grab or read all the bytes from an io.Reader anyway, so this can
+// save having to copy the bytes or create a bytes.Buffer.
+func DecodeBytes(na ipld.NodeAssembler, src []byte) error {
+	nodeBytes, kind, err := decodeNode(src)
+	if err != nil {
+		return err
+	}
+	ma, err := na.BeginMap(1)
+	if err != nil {
+		return err
+	}
+	switch kind {
+	case INNER_NODE:
+		if err := ma.AssembleKey().AssignString(INNER_NODE.String()); err != nil {
+			return err
+		}
+		extNodeMA, err := ma.AssembleValue().BeginMap(2)
+		if err != nil {
+			return err
+		}
+		if err := unpackInnerNode(extNodeMA, nodeBytes); err != nil {
+			return err
+		}
+		if err := extNodeMA.Finish(); err != nil {
+			return err
+		}
+	case LEAF_NODE:
+		if err := ma.AssembleKey().AssignString(LEAF_NODE.String()); err != nil {
+			return err
+		}
+		leafNodeMA, err := ma.AssembleValue().BeginMap(1)
+		if err != nil {
+			return err
+		}
+		if err := unpackLeafNode(leafNodeMA, nodeBytes); err != nil {
+			return err
+		}
+		if err := leafNodeMA.Finish(); err != nil {
+			return err
+		}
+	default:
+		return fmt.Errorf("unrecognized NodeKind (%s)", kind.String())
+	}
+
+	return ma.Finish()
+}
+
+func unpackInnerNode(ma ipld.MapAssembler, nodeBytes []byte) error {
+	left, right := nodeBytes[:hashSize], nodeBytes[hashSize:]
+	if err := ma.AssembleKey().AssignString("Left"); err != nil {
+		return err
+	}
+	if bytes.Equal(left, placeholder) {
+		if err := ma.AssembleValue().AssignNull(); err != nil {
+			return err
+		}
+	} else {
+		leftCID := sha256ToCid(MultiCodecType, left)
+		leftCIDLink := cidlink.Link{Cid: leftCID}
+		if err := ma.AssembleValue().AssignLink(leftCIDLink); err != nil {
+			return err
+		}
+	}
+	if err := ma.AssembleKey().AssignString("Right"); err != nil {
+		return err
+	}
+	if bytes.Equal(right, placeholder) {
+		return ma.AssembleValue().AssignNull()
+	}
+	rightCID := sha256ToCid(MultiCodecType, right)
+	rightCIDLink := cidlink.Link{Cid: rightCID}
+	return ma.AssembleValue().AssignLink(rightCIDLink)
+}
+
+func unpackLeafNode(ma ipld.MapAssembler, leafBytes []byte) error {
+	path, val := leafBytes[:hashSize], leafBytes[hashSize:]
+	if err := ma.AssembleKey().AssignString("Value"); err != nil {
+		return err
+	}
+	if err := ma.AssembleValue().AssignBytes(val); err != nil {
+		return err
+	}
+	if err := ma.AssembleKey().AssignString("Path"); err != nil {
+		return err
+	}
+	return ma.AssembleValue().AssignBytes(path)
+}
+
+// sha256ToCid takes a sha256 hash and returns its cid based on
+// the codec given.
+func sha256ToCid(codec uint64, h []byte) cid.Cid {
+	buf, err := multihash.Encode(h, multihash.SHA2_256)
+	if err != nil {
+		panic(err)
+	}
+
+	return cid.NewCidV1(codec, multihash.Multihash(buf))
+}
+
+// returns node without prefix and the kind of the node
+func decodeNode(src []byte) ([]byte, NodeKind, error) {
+	switch {
+	case bytes.HasPrefix(src, innerPrefix):
+		return src[1:], INNER_NODE, nil
+	case bytes.HasPrefix(src, leafPrefix):
+		return src[1:], LEAF_NODE, nil
+	default:
+		return nil, "", fmt.Errorf("merkle tree node has unrecognized prefix %x", src[0])
+	}
+}


### PR DESCRIPTION
Cosmos SMT leafs are of the form `0x0 || path || value` where `path = sha256(key)` and `value = sha256(key || stateValue)` where `key` and `stateValue` are the kv pair stored in a separate state storage database (`stateValue` is either protobuf of amino encoded).

It's not possible to do further decoding of the `hash(key, stateValue)` values. If instead SMTs stored `hash(stateValue)` in their leaf nodes this would form a proper content hash link that we could decode.

Towards #3